### PR TITLE
fixed inability to read environmental variables

### DIFF
--- a/src/minswap/assets.py
+++ b/src/minswap/assets.py
@@ -6,10 +6,13 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Dict, MutableSet, Optional, Tuple, Union
 
+import os
 import blockfrost
-from dotenv import dotenv_values
+from dotenv import load_dotenv
 
 from minswap.models import AssetIdentity, Assets
+
+load_dotenv()
 
 cache_path = Path(__file__).parent.joinpath("data/assets")
 cache_path.mkdir(exist_ok=True, parents=True)
@@ -32,8 +35,8 @@ def update_asset_info(asset: str) -> Optional[AssetIdentity]:
     """
     asset_path = cache_path.joinpath(asset)
 
-    env = dotenv_values()
-    api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+    
+    api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
     info = api.asset(asset, return_type="json")
 
     asset_id = AssetIdentity.parse_obj(info)
@@ -185,8 +188,8 @@ def circulating_asset(
         The first output is the amount of circulating asset, the second output is the
             total minted asset.
     """
-    env = dotenv_values()
-    api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+    
+    api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
 
     hashes = [tx["tx_hash"] for tx in api.asset_history(asset, return_type="json")]
 

--- a/src/minswap/pools.py
+++ b/src/minswap/pools.py
@@ -4,8 +4,9 @@ from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional, Tuple, Union
 
+import os
 import blockfrost
-from dotenv import dotenv_values
+from dotenv import load_dotenv
 from pydantic import BaseModel, root_validator
 
 from minswap import addr
@@ -20,6 +21,8 @@ from minswap.models import (
     TxContentUtxo,
     TxIn,
 )
+
+load_dotenv()
 
 logging.basicConfig(
     format="%(asctime)s - %(name)-8s - %(levelname)-8s - %(message)s",
@@ -161,8 +164,8 @@ class PoolState(BaseModel):
         logger.debug(f"_get_asset_info: {value}")
         if value == "lovelace":
             return "lovelace"
-        env = dotenv_values()
-        api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+        
+        api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
         info = api.asset(value, return_type="json")
         return bytes.fromhex(AssetIdentity.parse_obj(info).asset_name).decode()
 
@@ -308,8 +311,8 @@ def get_pools(
     Returns:
         A list of pools, and a list of non-pool UTxOs
     """
-    env = dotenv_values()
-    api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+    
+    api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
 
     utxos_raw = api.address_utxos(
         addr.POOL.address.encode(), gather_pages=True, order="asc", return_type="json"
@@ -349,8 +352,8 @@ def get_pool_in_tx(tx_hash: str) -> Optional[PoolState]:
     Returns:
         A `PoolState` if a pool is token is found, and `None` otherwise.
     """
-    env = dotenv_values()
-    api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+    
+    api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
 
     pool_tx = api.transaction_utxos(tx_hash, return_type="json")
     pool_utxo = None
@@ -382,8 +385,8 @@ def get_pool_by_id(pool_id: str) -> Optional[PoolState]:
     Returns:
         A `PoolState` if the pool can be found, and `None` otherwise.
     """
-    env = dotenv_values()
-    api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+    
+    api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
 
     nft = f"{addr.POOL_NFT_POLICY_ID}{pool_id}"
     nft_txs = api.asset_transactions(
@@ -415,8 +418,8 @@ def get_pool_history(
     Returns:
         A list of `PoolHistory` items.
     """
-    env = dotenv_values()
-    api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+    
+    api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
 
     nft = f"{addr.POOL_NFT_POLICY_ID}{pool_id}"
     nft_txs = api.asset_transactions(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
+import os
 import blockfrost
-from dotenv import dotenv_values
+from dotenv import load_dotenv
 
-
+load_dotenv()
 def api():
 
-    env = dotenv_values()
-    api = blockfrost.BlockFrostApi(env["PROJECT_ID"])
+    
+    api = blockfrost.BlockFrostApi(os.getenv("PROJECT_ID"))
 
     return api


### PR DESCRIPTION
As the title suggests, for some reason, after creating a .env file and setting the variables correctly, there were still problems trying to gettheir values.

so, I propose a fix. 
Using `os.getenv("PROJECT_ID")` to read the variables.
This worked for me but the already implemented env["PROJECT_ID"] didn't.

Thanks.